### PR TITLE
Implement the Max line length flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ pub fn get_content(file_name: &str) -> String {
     let a: String = match fs::read_to_string(&file_name) {
         Ok(v) => v,
         Err(e) => {
-            eprintln!("{e:?}");
-            return "".to_string();
+            eprintln!("{}", e.to_string());
+            std::process::exit(1);
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,10 @@ struct Args {
     #[arg(short, long = "words")]
     words: bool,
 
+    /// print the maximum display width
+    #[arg(short = 'L', long = "max-line-length")]
+    max_line_length: bool,
+
     /// file to be read
     #[arg()]
     file_name: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,14 @@ pub fn words(content: &str) -> usize {
     content.split_whitespace().count()
 }
 
+pub fn max_line_length(content: &str) -> usize {
+    content
+        .lines()
+        .max_by(|x, y| x.len().cmp(&y.len()))
+        .expect("Content is empty, no lines to compare.")
+        .len()
+}
+
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
@@ -78,6 +86,7 @@ impl<'a> Iterator for ArgsIter<'a> {
             1 => Some((self.args.chars, chars)),
             2 => Some((self.args.lines, lines)),
             3 => Some((self.args.words, words)),
+            4 => Some((self.args.max_line_length, max_line_length)),
             _ => None,
         };
         self.index += 1;
@@ -88,7 +97,7 @@ impl<'a> Iterator for ArgsIter<'a> {
 fn main() {
     let mut args: Args = Args::parse();
 
-    if !args.bytes && !args.chars && !args.lines && !args.words {
+    if !args.bytes && !args.chars && !args.lines && !args.words && !args.max_line_length {
         args.bytes = true;
         args.lines = true;
         args.words = true;


### PR DESCRIPTION
Implement (-L, --max-line-length) flag to return the length of the longest line.

- Added a -L flag to the CLI, which computes and returns the length of the longest line in the provided input.

**_Usage:_**
```powershell
wc-cli -L [FILE]
wc-cli --max-line-length [FILE]
```