### PR TITLE
Total flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project is inspired by Unix's wc command, and it's here to help you count w
 - [x] Character Count (-c): How many characters are in your file? Find out!
 - [x] Longest Line (-L): Measure the length of the longest line for optimized file reading.
 - [x] Bytes Count (-m): Count the number of bytes in a file.
+- [ ] Total (--total): Show total counts across multiple files with always, never, or auto modes.
 
 ## 📦 Installation
 
@@ -36,6 +37,7 @@ Simple and intuitive to use! Just like the Unix wc command, but better 😉.
     -l, --lines            print the lines counts
     -w, --words            print the words counts
     -L, --max-line-length  print the maximum display width
+    --total <TOTAL>    when to print a line with total counts; [default: always] [possible values: auto, always, never]
     -h, --help             Print help
     -V, --version          Print version
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, fs, io};
 
-use clap::Parser;
+use clap::{builder::Str, Parser};
 
 pub fn get_content(file_name: &str) -> String {
     let a: String = match fs::read_to_string(&file_name) {
@@ -136,13 +136,13 @@ pub struct Total {
     max_line_length: usize,
 }
 
-struct File<'a> {
-    name: &'a str,
+struct File {
+    name: String,
     flags: Vec<Flag>,
 }
 
-impl<'a> File<'a> {
-    fn new(name: &'a str) -> Self {
+impl File {
+    fn new(name: String) -> Self {
         Self {
             name,
             flags: Vec::new(),
@@ -226,8 +226,8 @@ fn main() {
     }
 
     for file in &args.file_name {
-        let mut new_file = File::new(file);
-        let content: String = get_content(new_file.name);
+        let mut new_file = File::new(file.to_string());
+        let content: String = get_content(&new_file.name);
 
         for (enm, found, fun) in args_iter {
             if found {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,10 @@ pub struct Args {
     #[arg(short = 'L', long = "max-line-length")]
     max_line_length: bool,
 
+    /// when to print a line with total counts;
+    #[arg(long, default_value = "always", default_value_t = String::from("always"), value_parser=["auto", "always", "never", "only"])]
+    total: String,
+
     /// files to be read
     #[arg()]
     file_name: Vec<String>,
@@ -253,7 +257,7 @@ fn main() {
         println!();
     }
 
-    if files.len() > 1 {
+    if files.len() > 1 && ["auto", "always"].iter().any(|v| args.total == *v) {
         print_total(&total, &args);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,4 @@
-use std::{
-    fmt::Display,
-    fs,
-    io::{self, Error},
-};
+use std::{fmt::Display, fs, io};
 
 use clap::Parser;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,23 +14,23 @@ pub fn get_content(file_name: String) -> String {
     return a;
 }
 
-pub fn bytes(content: String) -> usize {
+pub fn bytes(content: &str) -> usize {
     content.as_bytes().len()
 }
 
-pub fn lines(content: String) -> usize {
+pub fn lines(content: &str) -> usize {
     content.lines().count()
 }
 
-pub fn chars(content: String) -> usize {
+pub fn chars(content: &str) -> usize {
     content.chars().count()
 }
 
-pub fn words(content: String) -> usize {
+pub fn words(content: &str) -> usize {
     content.split_whitespace().count()
 }
 
-pub fn max_line_length(content: String) -> usize {
+pub fn max_line_length(content: &str) -> usize {
     match content.lines().max_by(|x, y| x.len().cmp(&y.len())) {
         Some(v) => v,
         None => {
@@ -71,7 +71,7 @@ pub fn read_from_standard_input(args: &Args) {
 
     for (enm, found, fun) in args_iter2 {
         if found {
-            let val = enm(fun(content.clone()));
+            let val = enm(fun(&content));
 
             match val {
                 Flag::Bytes(m) => print_with_width(m, m.to_string().len()),
@@ -181,10 +181,10 @@ impl<'a> ArgsIter<'a> {
 }
 
 impl<'a> Iterator for ArgsIter<'a> {
-    type Item = (fn(usize) -> Flag, bool, fn(String) -> usize);
+    type Item = (fn(usize) -> Flag, bool, fn(&str) -> usize);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let result: Option<(fn(usize) -> Flag, bool, fn(String) -> usize)> = match self.index {
+        let result: Option<(fn(usize) -> Flag, bool, fn(&str) -> usize)> = match self.index {
             0 => Some((Flag::Bytes, self.args.bytes, bytes)),
             1 => Some((Flag::Chars, self.args.chars, chars)),
             2 => Some((Flag::Lines, self.args.lines, lines)),
@@ -235,7 +235,7 @@ fn main() {
 
         for (enm, found, fun) in args_iter {
             if found {
-                let val = enm(fun(content.clone()));
+                let val = enm(fun(&content));
 
                 match val {
                     Flag::Bytes(m) => total.bytes += m,
@@ -257,7 +257,7 @@ fn main() {
         println!();
     }
 
-    if files.len() > 1 && ["auto", "always"].iter().cloned().any(|v| args.total == v) {
+    if files.len() > 1 && ["auto", "always"].iter().any(|v| args.total == *v) {
         print_total(&total, &args);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,7 +258,7 @@ fn main() -> Result<(), io::Error> {
         println!();
     }
 
-    if files.len() > 1 && ["auto", "always"].iter().any(|v| args.total == *v) {
+    if (files.len() > 1 && args.total == "auto") || (files.len() >= 1 && args.total == "always") {
         print_total(&total, &args);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,13 @@
-use std::{fmt::Display, fs, io};
+use std::{
+    fmt::Display,
+    fs,
+    io::{self, Error},
+};
 
 use clap::Parser;
 
-pub fn get_content(file_name: String) -> String {
-    let a: String = match fs::read_to_string(&file_name) {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("{}", e.to_string());
-            std::process::exit(1);
-        }
-    };
-
-    return a;
+pub fn get_content(file_name: &str) -> Result<String, io::Error> {
+    fs::read_to_string(&file_name)
 }
 
 pub fn bytes(content: &str) -> usize {
@@ -201,7 +197,7 @@ impl<'a> Iterator for ArgsIter<'a> {
     }
 }
 
-fn main() {
+fn main() -> Result<(), io::Error> {
     let mut args: Args = Args::parse();
 
     if [
@@ -225,13 +221,14 @@ fn main() {
 
     let mut total = Total::default();
 
-    if args.file_name.len() == 0 {
+    if args.file_name.is_empty() {
         read_from_standard_input(&args);
+        return Ok(());
     }
 
     for file in &args.file_name {
         let mut new_file = File::new(file);
-        let content: String = get_content(new_file.name.to_owned());
+        let content: String = get_content(new_file.name)?;
 
         for (enm, found, fun) in args_iter {
             if found {
@@ -260,4 +257,6 @@ fn main() {
     if files.len() > 1 && ["auto", "always"].iter().any(|v| args.total == *v) {
         print_total(&total, &args);
     }
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,7 +224,15 @@ fn main() -> Result<(), io::Error> {
 
     for file in &args.file_name {
         let mut new_file = File::new(file);
-        let content: String = get_content(new_file.name)?;
+        let content: String = match get_content(new_file.name) {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(io::Error::new(
+                    e.kind(),
+                    format!("Error processing file {}: {}", new_file.name, e),
+                ));
+            }
+        };
 
         for (enm, found, fun) in args_iter {
             if found {

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ pub struct Args {
     max_line_length: bool,
 
     /// when to print a line with total counts;
-    #[arg(long, default_value = "always", default_value_t = String::from("always"), value_parser=["auto", "always", "never", "only"])]
+    #[arg(long, default_value = "always", default_value_t = String::from("always"), value_parser=["auto", "always", "never"])]
     total: String,
 
     /// files to be read

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,7 @@ fn main() {
         println!();
     }
 
-    if files.len() > 1 && ["auto", "always"].iter().any(|v| args.total == *v) {
+    if files.len() > 1 && ["auto", "always"].iter().cloned().any(|v| args.total == v) {
         print_total(&total, &args);
     }
 }


### PR DESCRIPTION
### Add `--total` flag to wc CLI

Introduced `--total` flag with options: `always`, `never`, `auto`

`always`: Show total count for all files.
`never`: Suppress total output.
`auto`: Show total only if multiple files are processed.